### PR TITLE
Pin database to fix breakages due to upstream database structure changes

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Setup environment
+        run: |
+            python -m pip install --upgrade pip
+            pip install .
+            pip install pytest
+
+      - name: Run Python tests
+        run: pytest

--- a/refractiveindex/refractiveindex.py
+++ b/refractiveindex/refractiveindex.py
@@ -36,7 +36,7 @@ class RefractiveIndex:
             urllib.request.urlretrieve(f'https://github.com/polyanskiy/refractiveindex.info-database/archive/{_DATABASE_SHA}.zip', zip_filename)
             print("extracting...", file=sys.stderr)
             with zipfile.ZipFile(zip_filename, 'r') as zf: zf.extractall(tempdir)
-            shutil.move(os.path.join(tempdir, "refractiveindex.info-database-master", "database"), databasePath)
+            shutil.move(os.path.join(tempdir, "refractiveindex.info-database-{_DATABASE_SHA}", "database"), databasePath)
             print("done", file=sys.stderr)
 
         self.referencePath = os.path.normpath(databasePath)

--- a/refractiveindex/refractiveindex.py
+++ b/refractiveindex/refractiveindex.py
@@ -36,7 +36,7 @@ class RefractiveIndex:
             urllib.request.urlretrieve(f'https://github.com/polyanskiy/refractiveindex.info-database/archive/{_DATABASE_SHA}.zip', zip_filename)
             print("extracting...", file=sys.stderr)
             with zipfile.ZipFile(zip_filename, 'r') as zf: zf.extractall(tempdir)
-            shutil.move(os.path.join(tempdir, "refractiveindex.info-database-{_DATABASE_SHA}", "database"), databasePath)
+            shutil.move(os.path.join(tempdir, f"refractiveindex.info-database-{_DATABASE_SHA}", "database"), databasePath)
             print("done", file=sys.stderr)
 
         self.referencePath = os.path.normpath(databasePath)

--- a/refractiveindex/refractiveindex.py
+++ b/refractiveindex/refractiveindex.py
@@ -14,6 +14,11 @@ except ImportError:
 # import collections
 
 
+# Commit on January 3, 2025 just prior to a major update of the database structure.
+# List of commits here: https://github.com/polyanskiy/refractiveindex.info-database/commits/master/
+_DATABASE_SHA = "451b9136b4b3566f6259b703990add5440ca125f"
+
+
 class RefractiveIndex:
     """Class that parses the refractiveindex.info YAML database"""
 
@@ -28,7 +33,7 @@ class RefractiveIndex:
           with tempfile.TemporaryDirectory() as tempdir:
             zip_filename = os.path.join(tempdir, "db.zip")
             print("downloading refractiveindex.info database...", file=sys.stderr)
-            urllib.request.urlretrieve('https://github.com/polyanskiy/refractiveindex.info-database/archive/refs/heads/master.zip', zip_filename)
+            urllib.request.urlretrieve(f'https://github.com/polyanskiy/refractiveindex.info-database/archive/refs/heads/{_DATABASE_SHA}.zip', zip_filename)
             print("extracting...", file=sys.stderr)
             with zipfile.ZipFile(zip_filename, 'r') as zf: zf.extractall(tempdir)
             shutil.move(os.path.join(tempdir, "refractiveindex.info-database-master", "database"), databasePath)

--- a/refractiveindex/refractiveindex.py
+++ b/refractiveindex/refractiveindex.py
@@ -33,7 +33,7 @@ class RefractiveIndex:
           with tempfile.TemporaryDirectory() as tempdir:
             zip_filename = os.path.join(tempdir, "db.zip")
             print("downloading refractiveindex.info database...", file=sys.stderr)
-            urllib.request.urlretrieve(f'https://github.com/polyanskiy/refractiveindex.info-database/archive/refs/heads/{_DATABASE_SHA}.zip', zip_filename)
+            urllib.request.urlretrieve(f'https://github.com/polyanskiy/refractiveindex.info-database/archive/{_DATABASE_SHA}.zip', zip_filename)
             print("extracting...", file=sys.stderr)
             with zipfile.ZipFile(zip_filename, 'r') as zf: zf.extractall(tempdir)
             shutil.move(os.path.join(tempdir, "refractiveindex.info-database-master", "database"), databasePath)

--- a/tests/test_refractiveindex.py
+++ b/tests/test_refractiveindex.py
@@ -1,0 +1,24 @@
+"""Tests for the python interface to the RefractiveIndex databse."""
+
+import unittest
+
+import refractiveindex as ri
+
+
+class RefractiveIndexTest(unittest.TestCase):
+    def test_basic_usage(self):
+        # Test the basic usage exercised in the project readme.
+        SiO = ri.RefractiveIndexMaterial(shelf='main', book='SiO', page='Hass')
+        wavelength_nm = 600
+
+        epsilon = SiO.get_epsilon(wavelength_nm)
+        expected_epsilon = 3.8633404437869827 + 0.003931076923076923j
+        self.assertAlmostEqual(epsilon, expected_epsilon)
+
+        refractive_index = SiO.get_refractive_index(wavelength_nm)
+        expected_refractive_index = 1.96553846
+        self.assertAlmostEqual(refractive_index, expected_refractive_index)
+
+        extinction_coefficient = SiO.get_extinction_coefficient(wavelength_nm)
+        expected_extinction_coefficient = 0.001
+        self.assertAlmostEqual(extinction_coefficient, expected_extinction_coefficient)


### PR DESCRIPTION
Hi @toftul , thanks for this package. I find it very useful for my work.

Unfortunately, due to some recent changes in the structure of the refractive index database, the existing parsing logic no works for the database at head. This PR pins the database to a specific commit prior to the changes, and adds a test that the basic functionality you have in the readme is valid. I also added a workflow which runs the test for new pull requests.

If this seems like a good move, could you merge and release a new version to pypi? Longer term, it would be good to update the parsing logic so that this package can benefit from the ongoing improvements to the database.

It might also be useful to work some integration with @polyanskiy's repo to catch any future breakages.